### PR TITLE
v0.3 (Beta): Bug hotfixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   },
   "dependencies": {
     "core-js": "^3.6.5",
-    "vue": "^2.6.11"
+    "vue": "^2.6.11",
+    "websocket-extensions": "^0.1.4"
   },
   "devDependencies": {
     "@vue/cli-plugin-babel": "~4.4.0",

--- a/src/components/Battleground.vue
+++ b/src/components/Battleground.vue
@@ -32,9 +32,9 @@
     },
     methods: {
       isClicked(event) {
-        if (event.path[1].dataset.bomb === 'bomb') {
+        if (event.target.parentNode.dataset.bomb === 'bomb') {
           alert(this.msgLost);
-          event.path[2].classList.add('show-all');
+          event.target.parentNode.parentNode.classList.add('show-all');
         }
 
         if (!event.target.classList.contains('flagged')) {
@@ -42,7 +42,7 @@
         }
       },
       isRightClicked(event) {
-        event.target.classList.add('flagged');
+        event.target.classList.toggle('flagged');
       },
       getCountOfCells(rows = this.rows, columns = this.columns) {
         return rows * columns;

--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -7,7 +7,7 @@
     <div class="footer-year">
       <a href="https://olegkruchay.com">olegkruchay.com</a> © 2020
     </div>
-    <p><a href="https://icons8.com/icon/118527/icons8">Icons8 icon by Icons8</a></p>
+    <p><a href="https://icons8.com/license">Icons by Icons8 (Free license).</a></p>
   </div>
 </template>
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8583,6 +8583,11 @@ websocket-extensions@>=0.1.1:
   resolved "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.3.tgz#5d2ff22977003ec687a4b87073dfbbac146ccf29"
   integrity sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg==
 
+websocket-extensions@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.4.tgz#7f8473bc839dfd87608adb95d7eb075211578a42"
+  integrity sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==
+
 which-module@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"


### PR DESCRIPTION
- Updated the license agreement with Icons8.com
- Fixed the bugs on Safari / Mozilla FF
- Updated a websocket-extensions npm package (Github security alert)